### PR TITLE
patches needed for building with VS 2010 and 2008

### DIFF
--- a/recipe/dfile.c.patch
+++ b/recipe/dfile.c.patch
@@ -1,0 +1,18 @@
+--- libdispatch\dfile.c.orig	2016-08-10 14:06:27.315735800 +1000
++++ libdispatch\dfile.c	2016-08-10 14:06:36.097008200 +1000
+@@ -166,6 +166,7 @@
+ 	{
+ 	    FILE *fp;
+ 	    size_t i;
++        __int64 file_len = 0;
+ #ifdef HAVE_SYS_STAT_H
+ 	    struct stat st;
+ #endif
+@@ -182,7 +183,6 @@
+ 
+         /* Windows and fstat have some issues, this will work around that. */
+ #ifdef HAVE_FILE_LENGTH_I64
+-        __int64 file_len = 0;
+         if((file_len = _filelengthi64(fileno(fp))) < 0) {
+           fclose(fp);
+           status = errno;

--- a/recipe/dim.c.patch
+++ b/recipe/dim.c.patch
@@ -1,0 +1,19 @@
+--- libsrc\dim.c.orig	2016-08-10 14:20:07.878295000 +1000
++++ libsrc\dim.c	2016-08-10 14:20:17.221986100 +1000
+@@ -444,6 +444,7 @@
+ 	int existid;
+ 	NC_dim *dimp;
+ 	char *newname;		/* normalized */
++    NC_string *old;
+ 
+ 	status = NC_check_id(ncid, &nc); 
+ 	if(status != NC_NOERR)
+@@ -465,7 +466,7 @@
+ 	if(dimp == NULL)
+ 		return NC_EBADDIM;
+ 
+-	NC_string *old = dimp->name;
++	old = dimp->name;
+ 	newname = (char *)utf8proc_NFC((const unsigned char *)unewname);
+ 	if(newname == NULL)
+ 	    return NC_ENOMEM;

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,9 @@ source:
     fn: v{{ version }}.tar.gz
     url: https://github.com/Unidata/netcdf-c/archive/v{{ version }}.tar.gz
     sha256: 17599385fd76ccdced368f448f654de2ed000fece44dece9fb5d598798b4c9d6
+    patches:
+        - dfile.c.patch  # [win]
+        - dim.c.patch  # [win]
 
 build:
     number: 0


### PR DESCRIPTION
Seems that bits of C99 code have snuck in - namely declaring variables after the first line of code in a block. These patches seem to fix it
